### PR TITLE
Use new Minicart

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,11 @@
     "vtex.store-drawer": "0.x",
     "vtex.breadcrumb": "1.x",
     "vtex.telemarketing": "2.x",
-    "vtex.order-placed": "1.x"
+    "vtex.order-placed": "1.x",
+    "vtex.checkout-summary": "0.x",
+    "vtex.product-list": "0.x",
+    "vtex.add-to-cart-button": "0.x",
+    "vtex.product-specification-badges": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -160,7 +160,7 @@
       "search-bar",
       "header-spacer",
       "login",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -341,22 +341,6 @@
       "showPasswordVerificationIntoTooltip": true
     }
   },
-  "minicart": {
-    "blocks": [
-      "product-summary"
-    ],
-    "props": {
-      "type": "popup",
-      "showRemoveButton": true,
-      "showDiscount": true,
-      "showSku": true,
-      "labelMiniCartEmpty": "",
-      "labelButtonFinishShopping": "Finalizar compra",
-      "enableQuantitySelector": true,
-      "maxQuantity": 10,
-      "labelClasses": "gray"
-    }
-  },
 
   "header-layout.mobile": {
     "children": [
@@ -370,7 +354,7 @@
       "logo.auto-image",
       "header-spacer",
       "login",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -1208,11 +1192,105 @@
 
 
   "store.product": {
-    "blocks": [
-      "product-details#default",
-      "product-kit",
+    "children": [
+      "flex-layout.row#product-breadcrumb",
+      "flex-layout.row#product-main",
+      "flex-layout.row#description",
       "shelf.relatedProducts"
     ]
+  },
+  "flex-layout.col#product-image": {
+    "children": ["flex-layout.row#product-image"]
+  },
+  "flex-layout.row#product-breadcrumb": {
+    "props": {
+      "marginTop": 4
+    },
+    "children": ["breadcrumb"]
+  },
+  "flex-layout.row#description": {
+    "props": {
+      "marginBottom": 7
+    },
+    "children": ["product-description"]
+  },
+  "flex-layout.row#product-main": {
+    "props": {
+      "colGap": 7,
+      "rowGap": 7,
+      "marginTop": 4,
+      "marginBottom": 7,
+      "paddingTop": 7,
+      "paddingBottom": 7
+    },
+    "children": ["flex-layout.col#product-image", "flex-layout.col#right-col"]
+  },
+
+  "product-specification-badges": {
+    "props": {
+      "specificationGroupName": "Group",
+      "specificationName": "On Sale",
+      "visibleWhen": "True",
+      "displayValue": "SPECIFICATION_NAME"
+    }
+  },
+
+  "flex-layout.row#product-image": {
+    "children": ["product-images"]
+  },
+  "product-images": {
+    "props": {
+      "displayThumbnailsArrows": true
+    }
+  },
+  "flex-layout.col#right-col": {
+    "props": {
+      "preventVerticalStretch": true,
+      "rowGap": 0
+    },
+    "children": [
+      "vtex.store-components:product-name",
+      "product-price#product-details",
+      "product-separator",
+      "sku-selector",
+      "flex-layout.row#buy-button",
+      "availability-subscriber",
+      "shipping-simulator",
+      "share#default"
+    ]
+  },
+
+  "sku-selector": {
+    "props": {
+      "variationsSpacing": 3,
+      "showValueNameForImageVariation": true
+    }
+  },
+
+  "product-price#product-details": {
+    "props": {
+      "showInstallments": true,
+      "showSavings": true
+    }
+  },
+
+  "flex-layout.row#buy-button": {
+    "props": {
+      "marginTop": 4,
+      "marginBottom": 7
+    },
+    "children": ["add-to-cart-button"]
+  },
+
+  "share#default": {
+    "props": {
+      "social": {
+        "Facebook": true,
+        "WhatsApp": true,
+        "Twitter": false,
+        "Pinterest": true
+      }
+    }
   },
 
 
@@ -1335,45 +1413,7 @@
 
 
 
-
-  "product-details#default": {
-    "blocks": [
-      "breadcrumb",
-      "product-name",
-      "product-images",
-      "product-price",
-      "product-description",
-      "product-specifications",
-      "buy-button",
-      "sku-selector",
-      "shipping-simulator",
-      "availability-subscriber",
-      "share"
-    ],
-    "props": {
-      "displayVertically": true,
-      "share": {
-        "social": {
-          "Facebook": true,
-          "WhatsApp": true,
-          "Twitter": false
-        }
-      },
-      "price": {
-        "labelSellingPrice": null,
-        "showListPrice": true,
-        "showLabels": true,
-        "showInstallments": true,
-        "showSavings": true
-      },
-      "name": {
-        "showBrandName": false,
-        "showSku": false,
-        "showProductReference": false
-      }
-    }
-  },
-  "buy-button": {
+  "add-to-cart-button": {
     "props": {
       "isOneClickBuy": true
     }

--- a/store/blocks/minicart.json
+++ b/store/blocks/minicart.json
@@ -1,0 +1,34 @@
+{
+  "minicart.v2": {
+    "children": ["minicart-base-content"]
+  },
+  "minicart-base-content": {
+    "blocks": ["minicart-product-list", "minicart-summary", "minicart-empty-state"]
+  },
+  "minicart-product-list": {
+    "blocks": ["product-list"]
+  },
+  "minicart-summary": {
+    "blocks": ["checkout-summary.compact"]
+  },
+  "checkout-summary.compact": {
+    "children": ["summary-totalizers#minicart"],
+    "props": {
+      "totalizersToShow": ["Items", "Discounts"]
+    }
+  },
+  "summary-totalizers#minicart": {
+    "props": {
+      "showTotal": true,
+      "showDeliveryTotal": false
+    }
+  },
+  "minicart-empty-state": {
+    "children": ["rich-text#empty-state"]
+  },
+  "rich-text#empty-state": {
+    "props": {
+      "text": "Seu carrinho está vazio!"
+    }
+  }
+}

--- a/store/blocks/product-list.json
+++ b/store/blocks/product-list.json
@@ -1,0 +1,57 @@
+{
+  "product-list": {
+    "blocks": [
+      "product-list-content-desktop",
+      "product-list-content-mobile"
+    ]
+  },
+  "product-list-content-mobile": {
+    "children": ["flex-layout.row#list-row.mobile"]
+  },
+  "flex-layout.row#list-row.mobile": {
+    "children": [
+      "flex-layout.col#image.mobile",
+      "flex-layout.col#main-container.mobile"
+    ],
+    "props": {
+      "fullWidth": true,
+      "paddingBottom": "6",
+      "paddingTop": "5",
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#main-container.mobile": {
+    "children": [
+      "flex-layout.row#top.mobile",
+      "flex-layout.row#quantity-selector.mobile",
+      "flex-layout.row#unit-price.mobile",
+      "flex-layout.row#price.mobile",
+      "flex-layout.row#message.mobile"
+    ],
+    "props": {
+      "width": "grow"
+    }
+  },
+  "flex-layout.row#top.mobile": {
+    "children": [
+      "flex-layout.col#product-description",
+      "flex-layout.col#remove-button.mobile"
+    ],
+    "props": {
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#product-description": {
+    "children": [
+      "flex-layout.row#product-name",
+      "flex-layout.row#product-variations"
+    ],
+    "props": {
+      "marginBottom": "5",
+      "width": "grow",
+      "preventVerticalStretch": "true"
+    }
+  }
+}


### PR DESCRIPTION
We want to make all GC stores use the new Cart we developed. In order to do that, we need to change the GC themes so that they use the new Minicart, since the current Minicart is not compatible with the new Cart.

This PR is a port of https://github.com/vtex-gocommerce/theme-gotheme-light/pull/8, which makes the necessary changes to the theme to make it use the new Minicart.

Test worskpace: https://black--gc-jqu0734.mygocommerce.com/
This workspace replaces the custom Madine theme with the black GC theme. That breaks the banners and the shelf, but the Minicart should work fine.